### PR TITLE
Implemetation interfaces and methods in facade

### DIFF
--- a/src/modules/bailyes/facade/bailyes-service.facade.ts
+++ b/src/modules/bailyes/facade/bailyes-service.facade.ts
@@ -15,6 +15,7 @@ import { UpdateSubjectGroupDto } from "../usecase/group/update-subject-group/upd
 import { BlockUnblockUserDto } from "../usecase/misc/block-unblock-user/block-unblock-user.dto";
 import { IsOnWhatsappDto } from "../usecase/misc/is-on-whatsapp/is-on-whatsapp.dto";
 import { GetUserStatusDto } from "../usecase/misc/get-status-user/get-status-user.dto";
+import { GetProfilePictureDto } from "../usecase/misc/get-profile-picture/get-profile-picture.dto";
 
 
 export interface UseCasesProps {
@@ -40,6 +41,7 @@ export interface UseCasesProps {
     verifyId: UseCaseInterface;
     blockUnblock: UseCaseInterface;
     getUserStatus: UseCaseInterface;
+    downloadProfile: UseCaseInterface;
 }
 
 export class BailyesServiceFacade implements WhatsappService {
@@ -60,6 +62,7 @@ export class BailyesServiceFacade implements WhatsappService {
     _verifyId: UseCaseInterface;
     _blockUnblock: UseCaseInterface;
     _getUserStatus: UseCaseInterface;
+    _downloadProfile: UseCaseInterface;
 
     constructor(props: UseCasesProps) {
         this._initUseCase = props.initUseCase;
@@ -79,6 +82,7 @@ export class BailyesServiceFacade implements WhatsappService {
         this._blockUnblock = props.blockUnblock;
         this._verifyId = props.verifyId;
         this._getUserStatus = props.getUserStatus;
+        this._downloadProfile = props.downloadProfile;
     }
 
     init(input: InitInstanceDto){
@@ -139,5 +143,9 @@ export class BailyesServiceFacade implements WhatsappService {
 
     getUserStatus(input: GetUserStatusDto) {
         return this._getUserStatus.execute(input);
+    }
+
+    downloadProfile(input: GetProfilePictureDto) {
+        return this._downloadProfile.execute(input);
     }
 }

--- a/src/modules/bailyes/facade/bailyes-service.facade.ts
+++ b/src/modules/bailyes/facade/bailyes-service.facade.ts
@@ -28,22 +28,22 @@ export interface UseCasesProps {
     sendTextMessageUseCase: UseCaseInterface;
     sendUrlMediaFileUseCase: UseCaseInterface;
     sendMediaFileUseCase: UseCaseInterface;
-    createNewGroup: UseCaseInterface;
+    createGroupUseCase: UseCaseInterface;
     //getAllGroups: UseCaseInterface;
-    leaveGroup: UseCaseInterface;
-    getInviteCodeGroup: UseCaseInterface;
+    leaveGroupUseCase: UseCaseInterface;
+    getInviteCodeGroupUseCase: UseCaseInterface;
     //groupFetchAllParticipating: UseCaseInterface;
     //groupParticipantsUpdate: UseCaseInterface;
     ///groupSettingUpdate: UseCaseInterface;
-    groupUpdateSubject: UseCaseInterface;
-    groupUpdateDescription: UseCaseInterface;
+    groupUpdateSubjectUseCase: UseCaseInterface;
+    groupUpdateDescriptionUseCase: UseCaseInterface;
     //groupGetInviteInfo: UseCaseInterface;
-    groupAcceptInvite: UseCaseInterface;
-    verifyId: UseCaseInterface;
-    blockUnblock: UseCaseInterface;
-    getUserStatus: UseCaseInterface;
-    downloadProfile: UseCaseInterface;
-    updateProfilePicture: UseCaseInterface;
+    groupAcceptInviteUseCase: UseCaseInterface;
+    verifyIdUseCase: UseCaseInterface;
+    blockUnblockUseCase: UseCaseInterface;
+    getUserStatusUseCase: UseCaseInterface;
+    downloadProfileUseCase: UseCaseInterface;
+    updateProfilePictureUseCase: UseCaseInterface;
 }
 
 export class BailyesServiceFacade implements WhatsappService {
@@ -76,17 +76,17 @@ export class BailyesServiceFacade implements WhatsappService {
         this._sendTextMessageUseCase = props.sendTextMessageUseCase;
         this._sendUrlMediaFileUseCase = props.sendUrlMediaFileUseCase;
         this._sendMediaFileUseCase = props.sendMediaFileUseCase;
-        this._createNewGroup = props.createNewGroup;
-        this._leaveGroup = props.leaveGroup;
-        this._getInviteCodeGroup = props.getInviteCodeGroup;
-        this._groupUpdateSubject = props.groupUpdateSubject;
-        this._groupUpdateDescription = props.groupUpdateDescription;
-        this._groupAcceptInvite = props.groupAcceptInvite;
-        this._blockUnblock = props.blockUnblock;
-        this._verifyId = props.verifyId;
-        this._getUserStatus = props.getUserStatus;
-        this._downloadProfile = props.downloadProfile;
-        this._updateProfilePicture = props.updateProfilePicture;
+        this._createNewGroup = props.createGroupUseCase;
+        this._leaveGroup = props.leaveGroupUseCase;
+        this._getInviteCodeGroup = props.getInviteCodeGroupUseCase
+        this._groupUpdateSubject = props.groupUpdateSubjectUseCase
+        this._groupUpdateDescription = props.groupUpdateDescriptionUseCase
+        this._groupAcceptInvite = props.groupAcceptInviteUseCase
+        this._blockUnblock = props.blockUnblockUseCase
+        this._verifyId = props.verifyIdUseCase
+        this._getUserStatus = props.getUserStatusUseCase
+        this._downloadProfile = props.downloadProfileUseCase
+        this._updateProfilePicture = props.updateProfilePictureUseCase
     }
 
     init(input: InitInstanceDto){

--- a/src/modules/bailyes/facade/bailyes-service.facade.ts
+++ b/src/modules/bailyes/facade/bailyes-service.facade.ts
@@ -6,6 +6,14 @@ import {GetQrCodeUseCaseDTO} from "../usecase/instance/get-qr-code/get-qr-code.u
 import {DeleteInstanceUseCaseDto} from "../usecase/instance/delete/delete-instance.usecase.dto";
 import {SendTextMessageUseCaseDto} from "../usecase/message/send-text-message/send-text-message.dto";
 import {SendUrlMediaFileUseCaseDto} from "../usecase/message/send-url-media-file/send-url-media-file.usecase.dto";
+import { CreateGroupDto } from "../usecase/group/create-group/create-group.dto";
+import { LeaveGroupDto } from "../usecase/group/leave-group/leave-group.dto";
+import { InviteCodeGroupDto } from "../usecase/group/invite-code-group/invite-code-group.dto";
+import { AcceptInviteGroupDto } from "../usecase/group/accept-invite-group/accept-invite-group.dto";
+import { UpdateDescriptionGroupDto } from "../usecase/group/update-description-group/update-description-group.dto";
+import { UpdateSubjectGroupDto } from "../usecase/group/update-subject-group/update-subject-group.dto";
+import { BlockUnblockUserDto } from "../usecase/misc/block-unblock-user/block-unblock-user.dto";
+import { IsOnWhatsappDto } from "../usecase/misc/is-on-whatsapp/is-on-whatsapp.dto";
 
 
 export interface UseCasesProps {
@@ -17,6 +25,19 @@ export interface UseCasesProps {
     sendTextMessageUseCase: UseCaseInterface;
     sendUrlMediaFileUseCase: UseCaseInterface;
     sendMediaFileUseCase: UseCaseInterface;
+    createNewGroup: UseCaseInterface;
+    //getAllGroups: UseCaseInterface;
+    leaveGroup: UseCaseInterface;
+    getInviteCodeGroup: UseCaseInterface;
+    //groupFetchAllParticipating: UseCaseInterface;
+    //groupParticipantsUpdate: UseCaseInterface;
+    ///groupSettingUpdate: UseCaseInterface;
+    groupUpdateSubject: UseCaseInterface;
+    groupUpdateDescription: UseCaseInterface;
+    //groupGetInviteInfo: UseCaseInterface;
+    groupAcceptInvite: UseCaseInterface;
+    verifyId: UseCaseInterface;
+    blockUnblock: UseCaseInterface;
 }
 
 export class BailyesServiceFacade implements WhatsappService {
@@ -28,6 +49,15 @@ export class BailyesServiceFacade implements WhatsappService {
     _sendTextMessageUseCase: UseCaseInterface;
     _sendUrlMediaFileUseCase: UseCaseInterface;
     _sendMediaFileUseCase: UseCaseInterface;
+    _createNewGroup: UseCaseInterface;
+    _leaveGroup: UseCaseInterface;
+    _getInviteCodeGroup: UseCaseInterface;
+    _groupUpdateSubject: UseCaseInterface;
+    _groupUpdateDescription: UseCaseInterface;
+    _groupAcceptInvite: UseCaseInterface;
+    _verifyId: UseCaseInterface;
+    _blockUnblock: UseCaseInterface;
+
     constructor(props: UseCasesProps) {
         this._initUseCase = props.initUseCase;
         this._infoUseCase = props.infoUseCase;
@@ -37,6 +67,14 @@ export class BailyesServiceFacade implements WhatsappService {
         this._sendTextMessageUseCase = props.sendTextMessageUseCase;
         this._sendUrlMediaFileUseCase = props.sendUrlMediaFileUseCase;
         this._sendMediaFileUseCase = props.sendMediaFileUseCase;
+        this._createNewGroup = props.createNewGroup;
+        this._leaveGroup = props.leaveGroup;
+        this._getInviteCodeGroup = props.getInviteCodeGroup;
+        this._groupUpdateSubject = props.groupUpdateSubject;
+        this._groupUpdateDescription = props.groupUpdateDescription;
+        this._groupAcceptInvite = props.groupAcceptInvite;
+        this._blockUnblock = props.blockUnblock;
+        this._verifyId = props.verifyId;
     }
 
     init(input: InitInstanceDto){
@@ -63,5 +101,35 @@ export class BailyesServiceFacade implements WhatsappService {
     sendMediaFile(input:SendMediaFileUseCaseDto){
         return this._sendMediaFileUseCase.execute(input)
     }
+    createNewGroup(input: CreateGroupDto) {
+        return this._createNewGroup.execute(input)
+    }
 
+    leaveGroup(input: LeaveGroupDto) {
+        return this._leaveGroup.execute(input);
+    }
+
+    getInviteCodeGroup(input: InviteCodeGroupDto) {
+        return this._getInviteCodeGroup.execute(input);
+    }
+
+    groupAcceptInvite(input: AcceptInviteGroupDto) {
+        return this._groupAcceptInvite.execute(input);
+    }
+
+    groupUpdateDescription(input: UpdateDescriptionGroupDto) {
+        return this._groupUpdateDescription.execute(input);
+    }
+
+    groupUpdateSubject(input: UpdateSubjectGroupDto) {
+        return this._groupUpdateSubject.execute(input);
+    }
+
+    blockUnblock(input: BlockUnblockUserDto) {
+        return this._blockUnblock.execute(input);
+    }
+
+    verifyId(input: IsOnWhatsappDto) {
+        return this._verifyId.execute(input);
+    }
 }

--- a/src/modules/bailyes/facade/bailyes-service.facade.ts
+++ b/src/modules/bailyes/facade/bailyes-service.facade.ts
@@ -19,6 +19,7 @@ import { GetProfilePictureDto } from "../usecase/misc/get-profile-picture/get-pr
 import { UpdateProfilePictureDto } from "../usecase/misc/update-profile-picture/update-profile-picture.dto";
 import { MakeUserGroupDto } from "../usecase/group/make-user-group/make-user-group.dto";
 import { UpdateSettingsGroupDto } from "../usecase/group/update-settings-group/update-settings-group.dto";
+import { GetInviteInGroupDto } from "../usecase/group/get-invite-info-group/get-invite-info-group.dto";
 
 
 export interface UseCasesProps {
@@ -40,7 +41,7 @@ export interface UseCasesProps {
     groupSettingUpdate: UseCaseInterface;
     groupUpdateSubjectUseCase: UseCaseInterface;
     groupUpdateDescriptionUseCase: UseCaseInterface;
-    //groupGetInviteInfo: UseCaseInterface;
+    groupGetInviteInfo: UseCaseInterface;
     groupAcceptInviteUseCase: UseCaseInterface;
     verifyIdUseCase: UseCaseInterface;
     blockUnblockUseCase: UseCaseInterface;
@@ -71,6 +72,7 @@ export class BailyesServiceFacade implements WhatsappService {
     _updateProfilePicture: UseCaseInterface;
     _makeUserGroupUseCase: UseCaseInterface;
     _groupSettingUpdate:  UseCaseInterface;
+    _groupGetInviteInfo: UseCaseInterface;
 
     constructor(props: UseCasesProps) {
         this._initUseCase = props.initUseCase;
@@ -94,6 +96,7 @@ export class BailyesServiceFacade implements WhatsappService {
         this._updateProfilePicture = props.updateProfilePictureUseCase;
         this._makeUserGroupUseCase = props.makeUserGroupUseCase;
         this._groupSettingUpdate = props.groupSettingUpdate;
+        this._groupGetInviteInfo = props.groupGetInviteInfo;
     }
 
     init(input: InitInstanceDto){
@@ -148,8 +151,12 @@ export class BailyesServiceFacade implements WhatsappService {
         return this._makeUserGroupUseCase.execute(input);
     }
 
-    groupSettingUpdate(input: UpdateSettingsGroupDto): Promise<void> {
+    groupSettingUpdate(input: UpdateSettingsGroupDto) {
         return this._groupSettingUpdate.execute(input);
+    }
+
+    groupGetInviteInfo(input: GetInviteInGroupDto) {
+        return this._groupGetInviteInfo.execute(input);
     }
 
     blockUnblock(input: BlockUnblockUserDto) {

--- a/src/modules/bailyes/facade/bailyes-service.facade.ts
+++ b/src/modules/bailyes/facade/bailyes-service.facade.ts
@@ -14,6 +14,7 @@ import { UpdateDescriptionGroupDto } from "../usecase/group/update-description-g
 import { UpdateSubjectGroupDto } from "../usecase/group/update-subject-group/update-subject-group.dto";
 import { BlockUnblockUserDto } from "../usecase/misc/block-unblock-user/block-unblock-user.dto";
 import { IsOnWhatsappDto } from "../usecase/misc/is-on-whatsapp/is-on-whatsapp.dto";
+import { GetUserStatusDto } from "../usecase/misc/get-status-user/get-status-user.dto";
 
 
 export interface UseCasesProps {
@@ -38,6 +39,7 @@ export interface UseCasesProps {
     groupAcceptInvite: UseCaseInterface;
     verifyId: UseCaseInterface;
     blockUnblock: UseCaseInterface;
+    getUserStatus: UseCaseInterface;
 }
 
 export class BailyesServiceFacade implements WhatsappService {
@@ -57,6 +59,7 @@ export class BailyesServiceFacade implements WhatsappService {
     _groupAcceptInvite: UseCaseInterface;
     _verifyId: UseCaseInterface;
     _blockUnblock: UseCaseInterface;
+    _getUserStatus: UseCaseInterface;
 
     constructor(props: UseCasesProps) {
         this._initUseCase = props.initUseCase;
@@ -75,6 +78,7 @@ export class BailyesServiceFacade implements WhatsappService {
         this._groupAcceptInvite = props.groupAcceptInvite;
         this._blockUnblock = props.blockUnblock;
         this._verifyId = props.verifyId;
+        this._getUserStatus = props.getUserStatus;
     }
 
     init(input: InitInstanceDto){
@@ -131,5 +135,9 @@ export class BailyesServiceFacade implements WhatsappService {
 
     verifyId(input: IsOnWhatsappDto) {
         return this._verifyId.execute(input);
+    }
+
+    getUserStatus(input: GetUserStatusDto) {
+        return this._getUserStatus.execute(input);
     }
 }

--- a/src/modules/bailyes/facade/bailyes-service.facade.ts
+++ b/src/modules/bailyes/facade/bailyes-service.facade.ts
@@ -17,6 +17,7 @@ import { IsOnWhatsappDto } from "../usecase/misc/is-on-whatsapp/is-on-whatsapp.d
 import { GetUserStatusDto } from "../usecase/misc/get-status-user/get-status-user.dto";
 import { GetProfilePictureDto } from "../usecase/misc/get-profile-picture/get-profile-picture.dto";
 import { UpdateProfilePictureDto } from "../usecase/misc/update-profile-picture/update-profile-picture.dto";
+import { MakeUserGroupDto } from "../usecase/group/make-user-group/make-user-group.dto";
 
 
 export interface UseCasesProps {
@@ -29,6 +30,7 @@ export interface UseCasesProps {
     sendUrlMediaFileUseCase: UseCaseInterface;
     sendMediaFileUseCase: UseCaseInterface;
     createGroupUseCase: UseCaseInterface;
+    makeUserGroupUseCase: UseCaseInterface;
     //getAllGroups: UseCaseInterface;
     leaveGroupUseCase: UseCaseInterface;
     getInviteCodeGroupUseCase: UseCaseInterface;
@@ -66,6 +68,7 @@ export class BailyesServiceFacade implements WhatsappService {
     _getUserStatus: UseCaseInterface;
     _downloadProfile: UseCaseInterface;
     _updateProfilePicture: UseCaseInterface;
+    _makeUserGroupUseCase: UseCaseInterface;
 
     constructor(props: UseCasesProps) {
         this._initUseCase = props.initUseCase;
@@ -86,7 +89,8 @@ export class BailyesServiceFacade implements WhatsappService {
         this._verifyId = props.verifyIdUseCase
         this._getUserStatus = props.getUserStatusUseCase
         this._downloadProfile = props.downloadProfileUseCase
-        this._updateProfilePicture = props.updateProfilePictureUseCase
+        this._updateProfilePicture = props.updateProfilePictureUseCase;
+        this._makeUserGroupUseCase = props.makeUserGroupUseCase;
     }
 
     init(input: InitInstanceDto){
@@ -135,6 +139,10 @@ export class BailyesServiceFacade implements WhatsappService {
 
     groupUpdateSubject(input: UpdateSubjectGroupDto) {
         return this._groupUpdateSubject.execute(input);
+    }
+
+    makeUserGroup(input: MakeUserGroupDto) {
+        return this._makeUserGroupUseCase.execute(input);
     }
 
     blockUnblock(input: BlockUnblockUserDto) {

--- a/src/modules/bailyes/facade/bailyes-service.facade.ts
+++ b/src/modules/bailyes/facade/bailyes-service.facade.ts
@@ -16,6 +16,7 @@ import { BlockUnblockUserDto } from "../usecase/misc/block-unblock-user/block-un
 import { IsOnWhatsappDto } from "../usecase/misc/is-on-whatsapp/is-on-whatsapp.dto";
 import { GetUserStatusDto } from "../usecase/misc/get-status-user/get-status-user.dto";
 import { GetProfilePictureDto } from "../usecase/misc/get-profile-picture/get-profile-picture.dto";
+import { UpdateProfilePictureDto } from "../usecase/misc/update-profile-picture/update-profile-picture.dto";
 
 
 export interface UseCasesProps {
@@ -42,6 +43,7 @@ export interface UseCasesProps {
     blockUnblock: UseCaseInterface;
     getUserStatus: UseCaseInterface;
     downloadProfile: UseCaseInterface;
+    updateProfilePicture: UseCaseInterface;
 }
 
 export class BailyesServiceFacade implements WhatsappService {
@@ -63,6 +65,7 @@ export class BailyesServiceFacade implements WhatsappService {
     _blockUnblock: UseCaseInterface;
     _getUserStatus: UseCaseInterface;
     _downloadProfile: UseCaseInterface;
+    _updateProfilePicture: UseCaseInterface;
 
     constructor(props: UseCasesProps) {
         this._initUseCase = props.initUseCase;
@@ -83,6 +86,7 @@ export class BailyesServiceFacade implements WhatsappService {
         this._verifyId = props.verifyId;
         this._getUserStatus = props.getUserStatus;
         this._downloadProfile = props.downloadProfile;
+        this._updateProfilePicture = props.updateProfilePicture;
     }
 
     init(input: InitInstanceDto){
@@ -147,5 +151,9 @@ export class BailyesServiceFacade implements WhatsappService {
 
     downloadProfile(input: GetProfilePictureDto) {
         return this._downloadProfile.execute(input);
+    }
+
+    updateProfilePicture(input: UpdateProfilePictureDto) {
+        return this._updateProfilePicture.execute(input);
     }
 }

--- a/src/modules/bailyes/facade/bailyes-service.facade.ts
+++ b/src/modules/bailyes/facade/bailyes-service.facade.ts
@@ -18,6 +18,7 @@ import { GetUserStatusDto } from "../usecase/misc/get-status-user/get-status-use
 import { GetProfilePictureDto } from "../usecase/misc/get-profile-picture/get-profile-picture.dto";
 import { UpdateProfilePictureDto } from "../usecase/misc/update-profile-picture/update-profile-picture.dto";
 import { MakeUserGroupDto } from "../usecase/group/make-user-group/make-user-group.dto";
+import { UpdateSettingsGroupDto } from "../usecase/group/update-settings-group/update-settings-group.dto";
 
 
 export interface UseCasesProps {
@@ -36,7 +37,7 @@ export interface UseCasesProps {
     getInviteCodeGroupUseCase: UseCaseInterface;
     //groupFetchAllParticipating: UseCaseInterface;
     //groupParticipantsUpdate: UseCaseInterface;
-    ///groupSettingUpdate: UseCaseInterface;
+    groupSettingUpdate: UseCaseInterface;
     groupUpdateSubjectUseCase: UseCaseInterface;
     groupUpdateDescriptionUseCase: UseCaseInterface;
     //groupGetInviteInfo: UseCaseInterface;
@@ -69,6 +70,7 @@ export class BailyesServiceFacade implements WhatsappService {
     _downloadProfile: UseCaseInterface;
     _updateProfilePicture: UseCaseInterface;
     _makeUserGroupUseCase: UseCaseInterface;
+    _groupSettingUpdate:  UseCaseInterface;
 
     constructor(props: UseCasesProps) {
         this._initUseCase = props.initUseCase;
@@ -91,6 +93,7 @@ export class BailyesServiceFacade implements WhatsappService {
         this._downloadProfile = props.downloadProfileUseCase
         this._updateProfilePicture = props.updateProfilePictureUseCase;
         this._makeUserGroupUseCase = props.makeUserGroupUseCase;
+        this._groupSettingUpdate = props.groupSettingUpdate;
     }
 
     init(input: InitInstanceDto){
@@ -143,6 +146,10 @@ export class BailyesServiceFacade implements WhatsappService {
 
     makeUserGroup(input: MakeUserGroupDto) {
         return this._makeUserGroupUseCase.execute(input);
+    }
+
+    groupSettingUpdate(input: UpdateSettingsGroupDto): Promise<void> {
+        return this._groupSettingUpdate.execute(input);
     }
 
     blockUnblock(input: BlockUnblockUserDto) {

--- a/src/modules/bailyes/facade/bailyes.facade.interface.ts
+++ b/src/modules/bailyes/facade/bailyes.facade.interface.ts
@@ -17,6 +17,7 @@ import { GetProfilePictureDto } from "../usecase/misc/get-profile-picture/get-pr
 import { UpdateProfilePictureDto } from "../usecase/misc/update-profile-picture/update-profile-picture.dto";
 import { MakeUserGroupDto } from "../usecase/group/make-user-group/make-user-group.dto";
 import { UpdateSettingsGroupDto } from "../usecase/group/update-settings-group/update-settings-group.dto";
+import { GetInviteInGroupDto } from "../usecase/group/get-invite-info-group/get-invite-info-group.dto";
 
 interface InstanceService {
     init(input: InitInstanceDto): Promise<void>;
@@ -43,7 +44,7 @@ interface GroupService {
     groupSettingUpdate(input: UpdateSettingsGroupDto): Promise<void>;
     groupUpdateSubject(input: UpdateSubjectGroupDto): Promise<any>;
     groupUpdateDescription(input: UpdateDescriptionGroupDto): Promise<any>;
-    //groupGetInviteInfo(): Promise<void>;
+    groupGetInviteInfo(input: GetInviteInGroupDto): Promise<void>;
     groupAcceptInvite(input: AcceptInviteGroupDto): Promise<any>;
 }
 

--- a/src/modules/bailyes/facade/bailyes.facade.interface.ts
+++ b/src/modules/bailyes/facade/bailyes.facade.interface.ts
@@ -16,6 +16,7 @@ import { GetUserStatusDto } from "../usecase/misc/get-status-user/get-status-use
 import { GetProfilePictureDto } from "../usecase/misc/get-profile-picture/get-profile-picture.dto";
 import { UpdateProfilePictureDto } from "../usecase/misc/update-profile-picture/update-profile-picture.dto";
 import { MakeUserGroupDto } from "../usecase/group/make-user-group/make-user-group.dto";
+import { UpdateSettingsGroupDto } from "../usecase/group/update-settings-group/update-settings-group.dto";
 
 interface InstanceService {
     init(input: InitInstanceDto): Promise<void>;
@@ -39,8 +40,7 @@ interface GroupService {
     makeUserGroup(input: MakeUserGroupDto): Promise<any>;
     //getInstanceInviteCodeGroup(): Promise<void>;
     //groupFetchAllParticipating(): Promise<void>;
-    //groupParticipantsUpdate(): Promise<void>;
-    //groupSettingUpdate(): Promise<void>;
+    groupSettingUpdate(input: UpdateSettingsGroupDto): Promise<void>;
     groupUpdateSubject(input: UpdateSubjectGroupDto): Promise<any>;
     groupUpdateDescription(input: UpdateDescriptionGroupDto): Promise<any>;
     //groupGetInviteInfo(): Promise<void>;

--- a/src/modules/bailyes/facade/bailyes.facade.interface.ts
+++ b/src/modules/bailyes/facade/bailyes.facade.interface.ts
@@ -4,6 +4,14 @@ import {GetQrCodeUseCaseDTO} from "../usecase/instance/get-qr-code/get-qr-code.u
 import {DeleteInstanceUseCaseDto} from "../usecase/instance/delete/delete-instance.usecase.dto";
 import {SendTextMessageUseCaseDto} from "../usecase/message/send-text-message/send-text-message.dto";
 import {SendUrlMediaFileUseCaseDto} from "../usecase/message/send-url-media-file/send-url-media-file.usecase.dto";
+import { CreateGroupDto } from "../usecase/group/create-group/create-group.dto";
+import { LeaveGroupDto } from "../usecase/group/leave-group/leave-group.dto";
+import { InviteCodeGroupDto } from "../usecase/group/invite-code-group/invite-code-group.dto";
+import { UpdateSubjectGroupDto } from "../usecase/group/update-subject-group/update-subject-group.dto";
+import { UpdateDescriptionGroupDto } from "../usecase/group/update-description-group/update-description-group.dto";
+import { AcceptInviteGroupDto } from "../usecase/group/accept-invite-group/accept-invite-group.dto";
+import { IsOnWhatsappDto } from "../usecase/misc/is-on-whatsapp/is-on-whatsapp.dto";
+import { BlockUnblockUserDto } from "../usecase/misc/block-unblock-user/block-unblock-user.dto";
 
 interface InstanceService {
     init(input: InitInstanceDto): Promise<void>;
@@ -20,31 +28,28 @@ interface MessageService {
 }
 
 interface GroupService {
-    createNewGroup(): Promise<void>;
-    addNewParticipant(): Promise<void>;
-    makeAdmin(): Promise<void>;
-    demoteAdmin(): Promise<void>;
-    getAllGroups(): Promise<void>;
-    leaveGroup(): Promise<void>;
-    getInviteCodeGroup(): Promise<void>;
-    getInstanceInviteCodeGroup(): Promise<void>;
-    groupFetchAllParticipating(): Promise<void>;
-    groupParticipantsUpdate(): Promise<void>;
-    groupSettingUpdate(): Promise<void>;
-    groupUpdateSubject(): Promise<void>;
-    groupUpdateDescription(): Promise<void>;
-    groupGetInviteInfo(): Promise<void>;
-    groupAcceptInvite(): Promise<void>;
+    createNewGroup(input: CreateGroupDto): Promise<any>;
+    //getAllGroups(): Promise<void>;
+    leaveGroup(input: LeaveGroupDto): Promise<any>;
+    getInviteCodeGroup(input: InviteCodeGroupDto): Promise<any>;
+    //getInstanceInviteCodeGroup(): Promise<void>;
+    //groupFetchAllParticipating(): Promise<void>;
+    //groupParticipantsUpdate(): Promise<void>;
+    //groupSettingUpdate(): Promise<void>;
+    groupUpdateSubject(input: UpdateSubjectGroupDto): Promise<any>;
+    groupUpdateDescription(input: UpdateDescriptionGroupDto): Promise<any>;
+    //groupGetInviteInfo(): Promise<void>;
+    groupAcceptInvite(input: AcceptInviteGroupDto): Promise<any>;
 }
 
 interface MiscService {
-    verifyId(): Promise<void>;
-    downloadProfile(): Promise<void>;
-    getUserStatus(): Promise<void>;
-    blockUnblock(): Promise<void>;
-    updateProfilePicture(): Promise<void>;
-    getUserOrGroupById(): Promise<void>;
+    verifyId(input: IsOnWhatsappDto): Promise<any>;
+    // downloadProfile(): Promise<void>;
+    // getUserStatus(): Promise<void>;
+    blockUnblock(input: BlockUnblockUserDto): Promise<any>;
+    // updateProfilePicture(): Promise<void>;
+    // getUserOrGroupById(): Promise<void>;
 }
 
 // TODO: implement 'MiscService' and GroupService
-export interface WhatsappService extends  MessageService,  InstanceService {}
+export interface WhatsappService extends  MessageService,  InstanceService, GroupService, MiscService {}

--- a/src/modules/bailyes/facade/bailyes.facade.interface.ts
+++ b/src/modules/bailyes/facade/bailyes.facade.interface.ts
@@ -15,6 +15,7 @@ import { BlockUnblockUserDto } from "../usecase/misc/block-unblock-user/block-un
 import { GetUserStatusDto } from "../usecase/misc/get-status-user/get-status-user.dto";
 import { GetProfilePictureDto } from "../usecase/misc/get-profile-picture/get-profile-picture.dto";
 import { UpdateProfilePictureDto } from "../usecase/misc/update-profile-picture/update-profile-picture.dto";
+import { MakeUserGroupDto } from "../usecase/group/make-user-group/make-user-group.dto";
 
 interface InstanceService {
     init(input: InitInstanceDto): Promise<void>;
@@ -35,6 +36,7 @@ interface GroupService {
     //getAllGroups(): Promise<void>;
     leaveGroup(input: LeaveGroupDto): Promise<any>;
     getInviteCodeGroup(input: InviteCodeGroupDto): Promise<any>;
+    makeUserGroup(input: MakeUserGroupDto): Promise<any>;
     //getInstanceInviteCodeGroup(): Promise<void>;
     //groupFetchAllParticipating(): Promise<void>;
     //groupParticipantsUpdate(): Promise<void>;

--- a/src/modules/bailyes/facade/bailyes.facade.interface.ts
+++ b/src/modules/bailyes/facade/bailyes.facade.interface.ts
@@ -13,6 +13,7 @@ import { AcceptInviteGroupDto } from "../usecase/group/accept-invite-group/accep
 import { IsOnWhatsappDto } from "../usecase/misc/is-on-whatsapp/is-on-whatsapp.dto";
 import { BlockUnblockUserDto } from "../usecase/misc/block-unblock-user/block-unblock-user.dto";
 import { GetUserStatusDto } from "../usecase/misc/get-status-user/get-status-user.dto";
+import { GetProfilePictureDto } from "../usecase/misc/get-profile-picture/get-profile-picture.dto";
 
 interface InstanceService {
     init(input: InitInstanceDto): Promise<void>;
@@ -45,8 +46,8 @@ interface GroupService {
 
 interface MiscService {
     verifyId(input: IsOnWhatsappDto): Promise<any>;
-    // downloadProfile(): Promise<void>;
-    getUserStatus(input: GetUserStatusDto): Promise<void>;
+    downloadProfile(input: GetProfilePictureDto): Promise<any>;
+    getUserStatus(input: GetUserStatusDto): Promise<any>;
     blockUnblock(input: BlockUnblockUserDto): Promise<any>;
     // updateProfilePicture(): Promise<void>;
     // getUserOrGroupById(): Promise<void>;

--- a/src/modules/bailyes/facade/bailyes.facade.interface.ts
+++ b/src/modules/bailyes/facade/bailyes.facade.interface.ts
@@ -14,6 +14,7 @@ import { IsOnWhatsappDto } from "../usecase/misc/is-on-whatsapp/is-on-whatsapp.d
 import { BlockUnblockUserDto } from "../usecase/misc/block-unblock-user/block-unblock-user.dto";
 import { GetUserStatusDto } from "../usecase/misc/get-status-user/get-status-user.dto";
 import { GetProfilePictureDto } from "../usecase/misc/get-profile-picture/get-profile-picture.dto";
+import { UpdateProfilePictureDto } from "../usecase/misc/update-profile-picture/update-profile-picture.dto";
 
 interface InstanceService {
     init(input: InitInstanceDto): Promise<void>;
@@ -49,7 +50,7 @@ interface MiscService {
     downloadProfile(input: GetProfilePictureDto): Promise<any>;
     getUserStatus(input: GetUserStatusDto): Promise<any>;
     blockUnblock(input: BlockUnblockUserDto): Promise<any>;
-    // updateProfilePicture(): Promise<void>;
+    updateProfilePicture(input: UpdateProfilePictureDto): Promise<any>;
     // getUserOrGroupById(): Promise<void>;
 }
 

--- a/src/modules/bailyes/facade/bailyes.facade.interface.ts
+++ b/src/modules/bailyes/facade/bailyes.facade.interface.ts
@@ -12,6 +12,7 @@ import { UpdateDescriptionGroupDto } from "../usecase/group/update-description-g
 import { AcceptInviteGroupDto } from "../usecase/group/accept-invite-group/accept-invite-group.dto";
 import { IsOnWhatsappDto } from "../usecase/misc/is-on-whatsapp/is-on-whatsapp.dto";
 import { BlockUnblockUserDto } from "../usecase/misc/block-unblock-user/block-unblock-user.dto";
+import { GetUserStatusDto } from "../usecase/misc/get-status-user/get-status-user.dto";
 
 interface InstanceService {
     init(input: InitInstanceDto): Promise<void>;
@@ -45,7 +46,7 @@ interface GroupService {
 interface MiscService {
     verifyId(input: IsOnWhatsappDto): Promise<any>;
     // downloadProfile(): Promise<void>;
-    // getUserStatus(): Promise<void>;
+    getUserStatus(input: GetUserStatusDto): Promise<void>;
     blockUnblock(input: BlockUnblockUserDto): Promise<any>;
     // updateProfilePicture(): Promise<void>;
     // getUserOrGroupById(): Promise<void>;

--- a/src/modules/bailyes/factory/bailyes.factory.ts
+++ b/src/modules/bailyes/factory/bailyes.factory.ts
@@ -22,6 +22,7 @@ import { LogoutInstanceUseCase } from "../usecase/instance/logout/logout-instanc
 import { GetInfoUseCase } from "../usecase/instance/get-info/get-info.usecase";
 import { SendMediaFileUseCase } from "../usecase/message/send-media-file/send-media-file.usecase";
 import { IsOnWhatsappUseCase } from "../usecase/misc/is-on-whatsapp/is-on-whatsapp.useCase";
+import { MakeUserGroupUseCase } from "../usecase/group/make-user-group/make-user-group.useCase";
 
 export class BailyesFactory {
     static create(){
@@ -48,6 +49,7 @@ export class BailyesFactory {
         const groupUpdateSubjectUseCase = new UpdateSubjectGroupUseCase(baileysManager);
         const groupUpdateDescriptionUseCase = new UpdateDescriptionGroupUseCase(baileysManager);
         const groupAcceptInviteUseCase = new AcceptInviteGroupUseCase(baileysManager);
+        const makeUserGroupUseCase = new MakeUserGroupUseCase(baileysManager);
 
         const getUserStatusUseCase = new GetUserStatusUseCase(baileysManager);
         const downloadProfileUseCase = new GetProfilePictureUseCase(baileysManager);
@@ -74,7 +76,8 @@ export class BailyesFactory {
             getInviteCodeGroupUseCase,
             groupAcceptInviteUseCase,
             groupUpdateDescriptionUseCase,
-            groupUpdateSubjectUseCase
+            groupUpdateSubjectUseCase,
+            makeUserGroupUseCase
         });
     }
 }

--- a/src/modules/bailyes/factory/bailyes.factory.ts
+++ b/src/modules/bailyes/factory/bailyes.factory.ts
@@ -23,6 +23,7 @@ import { GetInfoUseCase } from "../usecase/instance/get-info/get-info.usecase";
 import { SendMediaFileUseCase } from "../usecase/message/send-media-file/send-media-file.usecase";
 import { IsOnWhatsappUseCase } from "../usecase/misc/is-on-whatsapp/is-on-whatsapp.useCase";
 import { MakeUserGroupUseCase } from "../usecase/group/make-user-group/make-user-group.useCase";
+import { UpdateSettingsGroupUseCase } from "../usecase/group/update-settings-group/update-settings-group.useCase";
 
 export class BailyesFactory {
     static create(){
@@ -50,6 +51,7 @@ export class BailyesFactory {
         const groupUpdateDescriptionUseCase = new UpdateDescriptionGroupUseCase(baileysManager);
         const groupAcceptInviteUseCase = new AcceptInviteGroupUseCase(baileysManager);
         const makeUserGroupUseCase = new MakeUserGroupUseCase(baileysManager);
+        const groupSettingUpdate = new UpdateSettingsGroupUseCase(baileysManager);
 
         const getUserStatusUseCase = new GetUserStatusUseCase(baileysManager);
         const downloadProfileUseCase = new GetProfilePictureUseCase(baileysManager);
@@ -77,7 +79,8 @@ export class BailyesFactory {
             groupAcceptInviteUseCase,
             groupUpdateDescriptionUseCase,
             groupUpdateSubjectUseCase,
-            makeUserGroupUseCase
+            makeUserGroupUseCase,
+            groupSettingUpdate
         });
     }
 }

--- a/src/modules/bailyes/factory/bailyes.factory.ts
+++ b/src/modules/bailyes/factory/bailyes.factory.ts
@@ -24,6 +24,7 @@ import { SendMediaFileUseCase } from "../usecase/message/send-media-file/send-me
 import { IsOnWhatsappUseCase } from "../usecase/misc/is-on-whatsapp/is-on-whatsapp.useCase";
 import { MakeUserGroupUseCase } from "../usecase/group/make-user-group/make-user-group.useCase";
 import { UpdateSettingsGroupUseCase } from "../usecase/group/update-settings-group/update-settings-group.useCase";
+import { GetInviteInfoGroupUseCase } from "../usecase/group/get-invite-info-group/get-invite-info-group.useCase";
 
 export class BailyesFactory {
     static create(){
@@ -52,6 +53,7 @@ export class BailyesFactory {
         const groupAcceptInviteUseCase = new AcceptInviteGroupUseCase(baileysManager);
         const makeUserGroupUseCase = new MakeUserGroupUseCase(baileysManager);
         const groupSettingUpdate = new UpdateSettingsGroupUseCase(baileysManager);
+        const groupGetInviteInfo = new GetInviteInfoGroupUseCase(baileysManager);
 
         const getUserStatusUseCase = new GetUserStatusUseCase(baileysManager);
         const downloadProfileUseCase = new GetProfilePictureUseCase(baileysManager);
@@ -80,7 +82,8 @@ export class BailyesFactory {
             groupUpdateDescriptionUseCase,
             groupUpdateSubjectUseCase,
             makeUserGroupUseCase,
-            groupSettingUpdate
+            groupSettingUpdate,
+            groupGetInviteInfo
         });
     }
 }

--- a/src/modules/bailyes/factory/bailyes.factory.ts
+++ b/src/modules/bailyes/factory/bailyes.factory.ts
@@ -4,14 +4,24 @@ import {AuthStateRepository} from "../repository/auth-state-repository";
 import {ProcessSocketEvent} from "../domain/process-socket-event";
 import {BaileysInstanceRepositoryInMemory} from "../repository/baileys-instance-repository-in-memory";
 import {GetQrCodeUsecase} from "../usecase/instance/get-qr-code/get-qr-code.usecase";
-import {GetInfoUsecase} from "../usecase/instance/get-info/get-info.usecase";
-import {LogoutInstanceUsecase} from "../usecase/instance/logout/logout-instance-usecase";
 import {DeleteInstanceUseCase} from "../usecase/instance/delete/delete-instance.useCase";
 import {SendTextMessageUseCase} from "../usecase/message/send-text-message/send-text-message.useCase";
 import {SendUrlMediaFileUseCase} from "../usecase/message/send-url-media-file/send-url-media-file.useCase";
-import {SendMediaFileUsecase} from "../usecase/message/send-media-file/send-media-file.usecase";
 import {AcceptInviteGroupUseCase} from "../usecase/group/accept-invite-group/accept-invite-group.useCase";
 import EventDispatcher from "../../@shared/domain/events/event-dispatcher";
+import { GetUserStatusUseCase } from "../usecase/misc/get-status-user/get-status-user.useCase";
+import { GetProfilePictureUseCase } from "../usecase/misc/get-profile-picture/get-profile-picture.useCase";
+import { UpdateProfilePictureUseCase } from "../usecase/misc/update-profile-picture/update-profile-picture.useCase";
+import { BlockUnblockUserUseCase } from "../usecase/misc/block-unblock-user/block-unblock-user.useCase";
+import { CreateGroupUseCase } from "../usecase/group/create-group/create-group.useCase";
+import { LeaveGroupUseCase } from "../usecase/group/leave-group/leave-group.useCase";
+import { InviteCodeGroupUseCase } from "../usecase/group/invite-code-group/invite-code-group.useCase";
+import { UpdateSubjectGroupUseCase } from "../usecase/group/update-subject-group/update-subject-group.useCase";
+import { UpdateDescriptionGroupUseCase } from "../usecase/group/update-description-group/update-description-group.useCase";
+import { LogoutInstanceUseCase } from "../usecase/instance/logout/logout-instance-usecase";
+import { GetInfoUseCase } from "../usecase/instance/get-info/get-info.usecase";
+import { SendMediaFileUseCase } from "../usecase/message/send-media-file/send-media-file.usecase";
+import { IsOnWhatsappUseCase } from "../usecase/misc/is-on-whatsapp/is-on-whatsapp.useCase";
 
 export class BailyesFactory {
     static create(){
@@ -24,13 +34,26 @@ export class BailyesFactory {
             eventDispatcher, authStateRepository,
             processSocketEvent, baileysManager,
         );
-        const infoUseCase = new GetInfoUsecase(baileysManager);
+        const infoUseCase = new GetInfoUseCase(baileysManager);
         const qrUseCase = new GetQrCodeUsecase(baileysManager);
-        const logoutUseCase = new LogoutInstanceUsecase(baileysManager);
+        const logoutUseCase = new LogoutInstanceUseCase(baileysManager);
         const deleteUseCase = new DeleteInstanceUseCase(baileysManager);
         const sendTextMessageUseCase = new SendTextMessageUseCase(baileysManager);
         const sendUrlMediaFileUseCase = new SendUrlMediaFileUseCase(baileysManager);
-        const sendMediaFileUseCase = new SendMediaFileUsecase(baileysManager);
+        const sendMediaFileUseCase = new SendMediaFileUseCase(baileysManager);
+
+        const createGroupUseCase = new CreateGroupUseCase(baileysManager);
+        const leaveGroupUseCase = new LeaveGroupUseCase(baileysManager);
+        const getInviteCodeGroupUseCase =  new InviteCodeGroupUseCase(baileysManager);
+        const groupUpdateSubjectUseCase = new UpdateSubjectGroupUseCase(baileysManager);
+        const groupUpdateDescriptionUseCase = new UpdateDescriptionGroupUseCase(baileysManager);
+        const groupAcceptInviteUseCase = new AcceptInviteGroupUseCase(baileysManager);
+
+        const getUserStatusUseCase = new GetUserStatusUseCase(baileysManager);
+        const downloadProfileUseCase = new GetProfilePictureUseCase(baileysManager);
+        const updateProfilePictureUseCase = new UpdateProfilePictureUseCase(baileysManager);
+        const verifyIdUseCase = new IsOnWhatsappUseCase(baileysManager);
+        const blockUnblockUseCase = new BlockUnblockUserUseCase(baileysManager);
 
         return new BailyesServiceFacade({
             initUseCase,
@@ -41,6 +64,17 @@ export class BailyesFactory {
             sendTextMessageUseCase,
             sendUrlMediaFileUseCase,
             sendMediaFileUseCase,
+            getUserStatusUseCase,
+            downloadProfileUseCase,
+            updateProfilePictureUseCase,
+            verifyIdUseCase,
+            blockUnblockUseCase,
+            createGroupUseCase,
+            leaveGroupUseCase,
+            getInviteCodeGroupUseCase,
+            groupAcceptInviteUseCase,
+            groupUpdateDescriptionUseCase,
+            groupUpdateSubjectUseCase
         });
     }
 }

--- a/src/modules/bailyes/usecase/group/accept-invite-group/accept-invite-group.dto.ts
+++ b/src/modules/bailyes/usecase/group/accept-invite-group/accept-invite-group.dto.ts
@@ -1,0 +1,4 @@
+export interface AcceptInviteGroupDto{
+  id: string;
+  codeGroup: string;
+}

--- a/src/modules/bailyes/usecase/group/accept-invite-group/accept-invite-group.useCase.ts
+++ b/src/modules/bailyes/usecase/group/accept-invite-group/accept-invite-group.useCase.ts
@@ -1,6 +1,6 @@
 import {BaileysInstanceRepositoryInMemory} from "../../../repository/baileys-instance-repository-in-memory";
 import {checkInstance} from "../../../helpers/check-Instance";
-import {AcceptInviteGroupDto} from "../../../../../../../application/abstractions/whatsapp-lib/whatsapp-lib.dto";
+import { AcceptInviteGroupDto } from "./accept-invite-group.dto";
 
 
 export class AcceptInviteGroupUseCase {

--- a/src/modules/bailyes/usecase/group/get-invite-info-group/get-invite-info-group.dto.ts
+++ b/src/modules/bailyes/usecase/group/get-invite-info-group/get-invite-info-group.dto.ts
@@ -1,0 +1,4 @@
+export interface GetInviteInGroupDto {
+  id: string;
+  code: string;
+}

--- a/src/modules/bailyes/usecase/group/get-invite-info-group/get-invite-info-group.useCase.ts
+++ b/src/modules/bailyes/usecase/group/get-invite-info-group/get-invite-info-group.useCase.ts
@@ -1,0 +1,21 @@
+import {BaileysInstanceRepositoryInMemory} from "../../../repository/baileys-instance-repository-in-memory";
+import {checkInstance} from "../../../helpers/check-Instance";
+import { GetInviteInGroupDto } from "./get-invite-info-group.dto";
+
+
+export class GetInviteInfoGroupUseCase {
+    constructor(
+        private baileysManager: BaileysInstanceRepositoryInMemory
+    ) {
+    }
+
+    async execute(input: GetInviteInGroupDto) {
+        const result = await checkInstance(input.id, this.baileysManager)
+
+        const sock = result.waSocket!
+        
+        const response =  await sock.groupGetInviteInfo(input.code);
+
+        return response;
+    }
+}

--- a/src/modules/bailyes/usecase/group/update-settings-group/update-settings-group.dto.ts
+++ b/src/modules/bailyes/usecase/group/update-settings-group/update-settings-group.dto.ts
@@ -1,0 +1,5 @@
+export interface UpdateSettingsGroupDto {
+  id: string;
+  groupId: string;
+  action: 'announcement' | 'not_announcement' | 'unlocked' | 'locked';
+}

--- a/src/modules/bailyes/usecase/group/update-settings-group/update-settings-group.useCase.ts
+++ b/src/modules/bailyes/usecase/group/update-settings-group/update-settings-group.useCase.ts
@@ -1,0 +1,25 @@
+import {BaileysInstanceRepositoryInMemory} from "../../../repository/baileys-instance-repository-in-memory";
+import {getWhatsAppId} from "../../../helpers/get-whats-app-Id";
+import {checkInstance} from "../../../helpers/check-Instance";
+import { UpdateSettingsGroupDto } from "./update-settings-group.dto";
+
+
+export class UpdateSettingsGroupUseCase {
+    constructor(
+        private baileysManager: BaileysInstanceRepositoryInMemory
+    ) {
+    }
+
+    async execute(input: UpdateSettingsGroupDto) {
+        const result = await checkInstance(input.id, this.baileysManager)
+
+        const sock = result.waSocket!
+        
+        const whatsappId = getWhatsAppId(input.groupId);
+        await result.verifyId(whatsappId);
+
+        const response =  await sock.groupSettingUpdate(whatsappId, input.action);
+        
+        return response;
+    }
+}

--- a/src/modules/bailyes/usecase/misc/block-unblock-user/block-unblock-user.useCase.ts
+++ b/src/modules/bailyes/usecase/misc/block-unblock-user/block-unblock-user.useCase.ts
@@ -3,7 +3,7 @@ import {getWhatsAppId} from "../../../helpers/get-whats-app-Id";
 import {checkInstance} from "../../../helpers/check-Instance";
 import { BlockUnblockUserDto } from "./block-unblock-user.dto";
 
-export class IsOnWhatsappUseCase {
+export class BlockUnblockUserUseCase {
     constructor(
         private baileysManager: BaileysInstanceRepositoryInMemory
     ) {

--- a/src/modules/bailyes/usecase/misc/get-profile-picture/get-profile-picture.dto.ts
+++ b/src/modules/bailyes/usecase/misc/get-profile-picture/get-profile-picture.dto.ts
@@ -1,0 +1,4 @@
+export interface GetProfilePictureDto {
+  id: string;
+  to: string;
+}

--- a/src/modules/bailyes/usecase/misc/get-profile-picture/get-profile-picture.useCase.ts
+++ b/src/modules/bailyes/usecase/misc/get-profile-picture/get-profile-picture.useCase.ts
@@ -1,0 +1,24 @@
+import {BaileysInstanceRepositoryInMemory} from "../../../repository/baileys-instance-repository-in-memory";
+import {getWhatsAppId} from "../../../helpers/get-whats-app-Id";
+import {checkInstance} from "../../../helpers/check-Instance";
+import { GetProfilePictureDto } from "./get-profile-picture.dto";
+
+export class GetProfilePictureUseCase {
+    constructor(
+        private baileysManager: BaileysInstanceRepositoryInMemory
+    ) {
+    }
+
+    async execute(input: GetProfilePictureDto) {
+        const result = await checkInstance(input.id, this.baileysManager)
+
+        const sock = result.waSocket!
+
+        const whatsappId = getWhatsAppId(input.to);
+        await result.verifyId(whatsappId);
+        
+        const response =  await sock.profilePictureUrl(whatsappId);
+
+        return response;
+    }
+}

--- a/src/modules/bailyes/usecase/misc/get-status-user/get-status-user.dto.ts
+++ b/src/modules/bailyes/usecase/misc/get-status-user/get-status-user.dto.ts
@@ -1,0 +1,4 @@
+export interface GetUserStatusDto {
+  id: string;
+  to: string;
+}

--- a/src/modules/bailyes/usecase/misc/get-status-user/get-status-user.useCase.ts
+++ b/src/modules/bailyes/usecase/misc/get-status-user/get-status-user.useCase.ts
@@ -1,0 +1,24 @@
+import {BaileysInstanceRepositoryInMemory} from "../../../repository/baileys-instance-repository-in-memory";
+import {getWhatsAppId} from "../../../helpers/get-whats-app-Id";
+import {checkInstance} from "../../../helpers/check-Instance";
+import { GetUserStatusDto } from "./get-status-user.dto";
+
+export class GetUserStatusUseCase {
+    constructor(
+        private baileysManager: BaileysInstanceRepositoryInMemory
+    ) {
+    }
+
+    async execute(input: GetUserStatusDto) {
+        const result = await checkInstance(input.id, this.baileysManager)
+
+        const sock = result.waSocket!
+
+        const whatsappId = getWhatsAppId(input.to);
+        await result.verifyId(whatsappId);
+        
+        const response =  await sock.fetchStatus(whatsappId)
+
+        return response;
+    }
+}

--- a/src/modules/bailyes/usecase/misc/update-profile-picture/update-profile-picture.dto.ts
+++ b/src/modules/bailyes/usecase/misc/update-profile-picture/update-profile-picture.dto.ts
@@ -1,0 +1,5 @@
+export interface UpdateProfilePictureDto {
+  id: string;
+  to: string;
+  url: string;
+}

--- a/src/modules/bailyes/usecase/misc/update-profile-picture/update-profile-picture.useCase.ts
+++ b/src/modules/bailyes/usecase/misc/update-profile-picture/update-profile-picture.useCase.ts
@@ -1,0 +1,26 @@
+import {BaileysInstanceRepositoryInMemory} from "../../../repository/baileys-instance-repository-in-memory";
+import {getWhatsAppId} from "../../../helpers/get-whats-app-Id";
+import {checkInstance} from "../../../helpers/check-Instance";
+import { UpdateProfilePictureDto } from "./update-profile-picture.dto";
+
+export class UpdateProfilePictureUseCase {
+    constructor(
+        private baileysManager: BaileysInstanceRepositoryInMemory
+    ) {
+    }
+
+    async execute(input: UpdateProfilePictureDto) {
+        const result = await checkInstance(input.id, this.baileysManager)
+
+        const sock = result.waSocket!
+
+        const whatsappId = getWhatsAppId(input.to);
+        await result.verifyId(whatsappId);
+        
+        const response =  await sock.updateProfilePicture(whatsappId, {
+          url: input.url
+        });
+
+        return response;
+    }
+}


### PR DESCRIPTION
## Objetivo

Implementar as `interfaces` dos métodos de grupos já criados no facade, e adicionar novos métodos para gerenciamento de grupos;

## Adicionado
[x] Parâmetros na interface do facade
[x] Métodos na classe do facade;
[x] Caso de uso para buscar imagem de perfil;
[x] Caso de uso para buscar status do usuário;
[x] Caso de uso para atualizar imagem de perfil;
[x] Caso de uso configurações do grupo;
[x] Caso de uso para buscar informações do convite para o grupo;
[x] Caso de uso para atualizar usuários do grupo;