### PR TITLE
Delete instance baileys

### DIFF
--- a/src/main/compose/baileys/bailyes.composer.ts
+++ b/src/main/compose/baileys/bailyes.composer.ts
@@ -7,6 +7,9 @@ import {
     GetQrCodeController
 } from "../../../presentation/controllers/baileys-controllers/instance/get-qr-code.controller";
 import { AcceptInviteGroupController } from "../../../presentation/controllers/baileys-controllers/group/accep-invite-group.controller";
+import {
+    DeleteInstanceController
+} from "../../../presentation/controllers/baileys-controllers/instance/delete-instance.controller";
 
 export class BaileysComposer{
     private static baileysFactory = BaileysFactory.create()
@@ -14,14 +17,13 @@ export class BaileysComposer{
         const init = new InitBaileysController(this.baileysFactory);
         const acceptInviteGroup = new AcceptInviteGroupController(this.baileysFactory);
         const qr = new GetQrCodeController(this.baileysFactory);
+        const del = new DeleteInstanceController(this.baileysFactory)
 
         return new BaileysControllerFacade({
             init,
             qr,
-            acceptInviteGroup
+            acceptInviteGroup,
+            delete: del
         })
-
-
-
     }
 }

--- a/src/main/routes/instance.route.ts
+++ b/src/main/routes/instance.route.ts
@@ -9,6 +9,10 @@ instanceRoute.post(
     '/instance',
     (req: Request, res: Response) =>  requestAdapter(req, res, controller.init)
 )
+instanceRoute.delete(
+    '/instance/:id',
+    (req: Request, res: Response) => requestAdapter(req, res, controller.delete)
+)
 
 instanceRoute.get(
     '/instance/:id/qr',

--- a/src/presentation/controllers/baileys-controllers/index.ts
+++ b/src/presentation/controllers/baileys-controllers/index.ts
@@ -7,7 +7,7 @@ export class BaileysControllerFacade {
         // info: ControllerInterface;
         qr: ControllerInterface;
         // logout: ControllerInterface;
-        // delete: ControllerInterface;
+        delete: ControllerInterface;
         // sendTextMessage: ControllerInterface;
         // sendUrlMediaFile: ControllerInterface;
         // sendMediaFile: ControllerInterface;
@@ -18,7 +18,7 @@ export class BaileysControllerFacade {
     // get info() { return this.props.info; }
     get qr() { return this.props.qr; }
     // get logout() { return this.props.logout; }
-    // get delete() { return this.props.delete; }
+    get delete() { return this.props.delete; }
     // get sendTextMessage() { return this.props.sendTextMessage; }
     // get sendUrlMediaFile() { return this.props.sendUrlMediaFile; }
     // get sendMediaFile() { return this.props.sendMediaFile; }

--- a/src/presentation/controllers/baileys-controllers/instance/delete-instance.controller.ts
+++ b/src/presentation/controllers/baileys-controllers/instance/delete-instance.controller.ts
@@ -1,0 +1,30 @@
+import {WhatsappService} from "../../../../modules/baileys/facade/baileys.facade.interface";
+import {HttpRequest} from "../../../http-types/http-request";
+import {HttpResponse} from "../../../http-types/http-response";
+import {deleteInstanceValidator} from "../../../validators/delete-instance.validator";
+
+
+export class DeleteInstanceController {
+    constructor(
+        private usecase: WhatsappService
+    ) {
+    }
+
+
+    async handle(request: HttpRequest): Promise<HttpResponse> {
+        const {id} = request.params;
+        deleteInstanceValidator.validateSync({id})
+
+        await this.usecase.delete({
+            id
+        });
+
+        return new HttpResponse(
+            {
+                message: 'Instance successfully deleted.',
+            },
+            {"Content-Type": "application/json"},
+            200
+        )
+    }
+}

--- a/src/presentation/validators/delete-instance.validator.ts
+++ b/src/presentation/validators/delete-instance.validator.ts
@@ -1,0 +1,5 @@
+import * as yup from "yup";
+
+export const deleteInstanceValidator = yup.object().shape({
+    id: yup.string().required(),
+})

--- a/test/e2e/delete-baileys-instance.e2e-spec.ts
+++ b/test/e2e/delete-baileys-instance.e2e-spec.ts
@@ -1,0 +1,49 @@
+import request from 'supertest';
+import {IncomingMessage, Server, ServerResponse} from 'http';
+import {app} from '../../src/main/server/app'
+import {faker} from '@faker-js/faker';
+import TestAgent from 'supertest/lib/agent';
+import {logger} from "../../src/modules/@shared/infra/logger";
+import {dbConnect, dbDisconnect} from "../../src/modules/@shared/infra/persistence/settings/connection";
+import {delay} from "./helper/delay";
+
+describe('Delete baileys instance', () => {
+    let server: Server<typeof IncomingMessage, typeof ServerResponse>;
+    let api: TestAgent;
+
+    beforeAll(async () => {
+        await dbConnect()
+        server = app.listen(() => logger.info('Server is running on port'));
+        api = request(server);
+    });
+
+    afterAll(async () => {
+        await dbDisconnect()
+        server.close();
+    });
+
+
+    it('should return 200 when DELETE /instance/:id', async () => {
+        const body = {
+            name: faker.animal.bear(),
+            belongsTo: faker.string.uuid()
+        }
+
+        const header = {
+            'Authorization': `Bearer ${process.env.TOKEN}`
+        }
+
+        const create = await api.post('/instance')
+            .set(header)
+            .send(body)
+
+        await delay(5)
+
+
+
+        const T = await api.delete(`/instance/${create.body.data.id}`)
+        expect(T.status).toBe(200);
+
+    }, 6000);
+
+});

--- a/test/e2e/get-qr-instance.e2e-spec.ts
+++ b/test/e2e/get-qr-instance.e2e-spec.ts
@@ -5,6 +5,7 @@ import {faker} from '@faker-js/faker';
 import TestAgent from 'supertest/lib/agent';
 import {logger} from "../../src/modules/@shared/infra/logger";
 import {dbConnect, dbDisconnect} from "../../src/modules/@shared/infra/persistence/settings/connection";
+import {delay} from "./helper/delay";
 
 describe('Get Qr Code', () => {
     let server: Server<typeof IncomingMessage, typeof ServerResponse>;
@@ -36,7 +37,7 @@ describe('Get Qr Code', () => {
             .set(header)
             .send(body)
 
-        await aguardarDezSegundos()
+        await delay(5)
 
         const T = await api.get(`/instance/${create.body.data.id}/qr?belongsTo=${body.belongsTo}`)
         expect(T.status).toBe(200);
@@ -46,10 +47,3 @@ describe('Get Qr Code', () => {
 
 });
 
-function aguardarDezSegundos(): Promise<void> {
-    return new Promise<void>((resolve) => {
-        setTimeout(() => {
-            resolve();
-        }, 5000);
-    });
-}

--- a/test/e2e/helper/delay.ts
+++ b/test/e2e/helper/delay.ts
@@ -1,0 +1,7 @@
+export function delay(seconds: number): Promise<void> {
+    return new Promise<void>((resolve) => {
+        setTimeout(() => {
+            resolve();
+        }, seconds * 1000);
+    });
+}


### PR DESCRIPTION
Este Pull Request implementa a funcionalidade de exclusão de instâncias do Baileys.  A funcionalidade permite que os usuários removam instâncias específicas do Baileys do banco de dados.

### Alterações Propostas:

- Implementação da rota DELETE /instance/:id para permitir a exclusão de instâncias do Baileys.

- Adição de lógica no servidor para lidar com a requisição DELETE e remover a instância correspondente do banco de dados.

- Atualização da documentação ou dos comentários, se necessário, para refletir a nova funcionalidade implementada.