### PR TITLE
fix: Remove Baileys Startup Duplicate

### DIFF
--- a/src/modules/baileys/usecase/instance/init/init-instance.usecase.ts
+++ b/src/modules/baileys/usecase/instance/init/init-instance.usecase.ts
@@ -19,7 +19,6 @@ export class InitInstanceUseCase {
       processSocketEvent: this.processSocketEvent,
     });
 
-    await baileys.init();
     await this.baileysManager.create(baileys);
 
     return {


### PR DESCRIPTION
this PR is intended to remove duplicate boot from the baileys socket